### PR TITLE
Updated Namecheap DDNS service

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ noip:
 
 namecheap:
   enabled: false
-  subdomain: '@' # subdomain of server, use '@' if none
+  subdomain: @ # subdomain of server, multiple subdomains can be updated if separated by a comma ',' e.g. mc,map
   domain: exampledomain.com
   token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx # The token under the "Advanced DNS" Section in your namecheap domain list
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ noip:
 
 namecheap:
   enabled: false
-  subdomain: '@' # subdomain of server, use '@' if none
+  subdomain: @ # subdomain of server, use @ if none, multiple subdomains can be updated if separated by a comma ',' e.g. mc,map
   domain: exampledomain.com
   token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx # The token under the "Advanced DNS" Section in your namecheap domain list
 


### PR DESCRIPTION
To provide better error messages for those using Namecheap, I'm parsing the XML response given by the Namecheap DDNS, while I was at it I implemented the ability to update multiple subdomains if more than 1 subdomain was provided. Java has no native way to parse XML, from my research I would've had to import some sort of library to do so. I figured importing an XML parsing library _just_ for Namecheap would be unnecessary, as such I'm just taking in the server response as one big string, and checking if it contains anything pertaining to an error. This doesn't like a great solution, but it works as intended.